### PR TITLE
Fix plugin settings parameters

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,19 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'updateGrid') {
-    chrome.storage.local.set({ gridSystem: message.gridSystem, gridWidth: message.gridWidth, gridGap: message.gridGap }, () => {
+    let gridWidth = message.gridWidth;
+    const screenWidth = window.screen.width;
+    if (gridWidth > screenWidth) {
+      gridWidth = (gridWidth / 1920) * screenWidth;
+    }
+
+    let gridGap = message.gridGap;
+    const gridSystem = message.gridSystem;
+    if (gridGap > gridWidth / gridSystem) {
+      gridGap = (gridWidth / gridSystem) * 0.2;
+    }
+
+    chrome.storage.local.set({ gridSystem, gridWidth, gridGap }, () => {
       console.log('Grid system, width, and gap updated');
       sendResponse({ status: 'success' });
     });

--- a/content.js
+++ b/content.js
@@ -136,6 +136,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 function displayGrid(gridSystem, gridWidth, gridGap) {
+  const screenWidth = window.screen.width;
+  if (gridWidth > screenWidth) {
+    gridWidth = (gridWidth / 1920) * screenWidth;
+  }
+
+  if (gridGap > gridWidth / gridSystem) {
+    gridGap = (gridWidth / gridSystem) * 0.2;
+  }
+
   let viewWidth = 1920;
   let oneGrid = gridWidth / gridSystem;
   let oneGapPercent = gridGap / oneGrid;

--- a/popup.html
+++ b/popup.html
@@ -42,7 +42,7 @@
       <option value="16">16 Grid</option>
     </select>
     <label for="grid-width">Grid Width:</label>
-    <input type="number" id="grid-width" name="grid-width" min="1" max="100" value="8">
+    <input type="number" id="grid-width" name="grid-width" min="1" max="1920" value="1680">
     <label for="grid-gap">Grid Gap:</label>
     <input type="number" id="grid-gap" name="grid-gap" min="1" max="100" value="28">
     <label for="drawing-checkbox">Enable Drawing:</label>

--- a/popup.js
+++ b/popup.js
@@ -25,3 +25,5 @@ document.getElementById('drawing-checkbox').addEventListener('change', function(
     }
   });
 });
+
+document.getElementById('grid-width').value = 1680;


### PR DESCRIPTION
Update grid system settings to address task requirements.

* **background.js**
  - Add logic to calculate grid width based on screen width if the grid width exceeds screen width.
  - Add logic to adjust grid gap if it exceeds grid width divided by grid system.

* **content.js**
  - Add logic to calculate grid width based on screen width if the grid width exceeds screen width.
  - Add logic to adjust grid gap if it exceeds grid width divided by grid system.

* **popup.html**
  - Update `grid-width` input field to have a default value of 1680.

* **popup.js**
  - Set `grid-width` input field value to 1680.

