### PR TITLE
Untitled

### DIFF
--- a/content.js
+++ b/content.js
@@ -119,6 +119,7 @@ let gridWidth = 1680;
 let gridGap = 28;
 
 chrome.storage.local.get(['gridSystem', 'gridWidth', 'gridGap'], (result) => {
+  console.log(result);
   gridSystem = result.gridSystem !== undefined ? result.gridSystem : 12;
   gridWidth = result.gridWidth !== undefined ? result.gridWidth : 1680;
   gridGap = result.gridGap !== undefined ? result.gridGap : 28;
@@ -126,6 +127,7 @@ chrome.storage.local.get(['gridSystem', 'gridWidth', 'gridGap'], (result) => {
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log(message);
   if (message.type === 'updateGrid') {
     gridSystem = message.gridSystem;
     gridWidth = message.gridWidth;
@@ -136,29 +138,31 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 function displayGrid(gridSystem, gridWidth, gridGap) {
-  const screenWidth = window.screen.width;
+  const screenWidth = window.innerWidth;
   if (gridWidth > screenWidth) {
+    gridGap = screenWidth / 1920 * gridGap;
     gridWidth = (gridWidth / 1920) * screenWidth;
   }
 
+  
   if (gridGap > gridWidth / gridSystem) {
     gridGap = (gridWidth / gridSystem) * 0.2;
   }
-
-  let viewWidth = 1920;
+  
   let oneGrid = gridWidth / gridSystem;
   let oneGapPercent = gridGap / oneGrid;
+  console.log(gridWidth, gridGap, oneGrid, oneGapPercent);
   let grid = document.createElement('div');
   grid.id = 'grid';
   grid.style.position = 'fixed';
   grid.style.top = '0';
   grid.style.left = `50%`;
   grid.style.transform = 'translateX(-50%)';
-  grid.style.width = `${gridWidth / viewWidth}%`;
+  grid.style.width = `${gridWidth}px`;
   grid.style.height = '100%';
   grid.style.pointerEvents = 'none';
   grid.style.zIndex = '9998';
   grid.style.backgroundSize = `${100 / gridSystem + 100 / gridSystem * oneGapPercent / gridSystem}% 100%`;
-  grid.style.backgroundImage = `linear-gradient(to right, rgb(160 0 0 / 10%) 0, rgb(160 0 0 / 10%) ${100 - oneGapPercent}%, transparent ${100 - oneGapPercent}%, transparent 100%)`;
+  grid.style.backgroundImage = `linear-gradient(to right, rgb(160 0 0 / 10%) 0, rgb(160 0 0 / 10%) ${100 - oneGapPercent * 100}%, transparent ${100 - oneGapPercent * 100}%, transparent 100%)`;
   document.body.appendChild(grid);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Web Page Ruler Tool",
-  "version": "1.0",
+  "version": "1.1",
   "description": "A tool to display a ruler on web pages, choose different grid systems and widths, and draw lines with length display.",
   "permissions": [
     "activeTab",

--- a/popup.js
+++ b/popup.js
@@ -5,13 +5,21 @@ document.getElementById('grid-form').addEventListener('submit', function(event) 
   const gridWidth = document.getElementById('grid-width').value;
   const gridGap = document.getElementById('grid-gap').value;
 
-  chrome.runtime.sendMessage({ type: 'updateGrid', gridSystem, gridWidth, gridGap }, function(response) {
-    if (response.status === 'success') {
-      console.log('Grid system, width, and gap updated');
-    } else {
-      console.error('Failed to update grid system, width, and gap');
-    }
+  chrome.storage.local.set({ gridSystem, gridWidth, gridGap }, () => {
+    console.log('Grid system, width, and gap updated');
   });
+
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    chrome.tabs.sendMessage(tabs[0].id, {
+      type: 'updateGrid',
+      gridSystem,
+      gridWidth,
+      gridGap
+    }, (response) => {
+      console.log(response.status);
+    });
+  });
+
 });
 
 document.getElementById('drawing-checkbox').addEventListener('change', function(event) {

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,7 @@
   height: 1px;
   background: blue;
   transform-origin: 0 0;
+  z-index: 10000;
 }
 
 .length-label {


### PR DESCRIPTION
Add console logs and update grid display logic.

* **content.js**
  * Add console logs to display storage and message results.
  * Update `displayGrid` function to use `window.innerWidth` instead of `window.screen.width`.
  * Adjust grid gap calculation based on screen width.
  * Remove unused `viewWidth` variable.
  * Update grid width and background image calculations.

* **popup.js**
  * Change from `chrome.runtime.sendMessage` to `chrome.storage.local.set` for storing grid settings.
  * Add logic to send a message to the active tab to update the grid.

* **styles.css**
  * Add `z-index` to `.ruler-line` class.

* **manifest.json**
  * Update version from 1.0 to 1.1.

