### PR TITLE
Fix update grid functionality

### DIFF
--- a/content.js
+++ b/content.js
@@ -144,11 +144,15 @@ function displayGrid(gridSystem, gridWidth, gridGap) {
     gridWidth = (gridWidth / 1920) * screenWidth;
   }
 
-  
   if (gridGap > gridWidth / gridSystem) {
     gridGap = (gridWidth / gridSystem) * 0.2;
   }
-  
+
+  let existingGrid = document.getElementById('grid');
+  if (existingGrid) {
+    document.body.removeChild(existingGrid);
+  }
+
   let oneGrid = gridWidth / gridSystem;
   let oneGapPercent = gridGap / oneGrid;
   console.log(gridWidth, gridGap, oneGrid, oneGapPercent);

--- a/popup.js
+++ b/popup.js
@@ -5,10 +5,6 @@ document.getElementById('grid-form').addEventListener('submit', function(event) 
   const gridWidth = document.getElementById('grid-width').value;
   const gridGap = document.getElementById('grid-gap').value;
 
-  chrome.storage.local.set({ gridSystem, gridWidth, gridGap }, () => {
-    console.log('Grid system, width, and gap updated');
-  });
-
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.tabs.sendMessage(tabs[0].id, {
       type: 'updateGrid',


### PR DESCRIPTION
Modify the `displayGrid` function in `content.js` to update the existing grid instead of creating a new one.

* **Remove existing grid**: Add logic to remove the existing grid before creating a new one.
* **Update grid directly**: Remove `chrome.storage.local.set` call in `submit` event listener in `popup.js` and add logic to update the grid directly.

