### PR TITLE
Add snapping feature to ruler tool

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -47,6 +47,10 @@
     <input type="number" id="grid-gap" name="grid-gap" min="1" max="100" value="28">
     <label for="drawing-checkbox">Enable Drawing:</label>
     <input type="checkbox" id="drawing-checkbox" name="drawing-checkbox" checked>
+    <label for="snapping-checkbox">Enable Snapping:</label>
+    <input type="checkbox" id="snapping-checkbox" name="snapping-checkbox">
+    <label for="snapping-range">Snapping Range:</label>
+    <input type="range" id="snapping-range" name="snapping-range" min="1" max="100" value="10">
     <button type="submit">Update Grid</button>
   </form>
   <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -30,4 +30,33 @@ document.getElementById('drawing-checkbox').addEventListener('change', function(
   });
 });
 
+document.getElementById('snapping-checkbox').addEventListener('change', function(event) {
+  const snappingEnabled = event.target.checked;
+
+  chrome.runtime.sendMessage({ type: 'toggleSnapping', snappingEnabled }, function(response) {
+    if (response.status === 'success') {
+      console.log('Snapping functionality toggled');
+    } else {
+      console.error('Failed to toggle snapping functionality');
+    }
+  });
+});
+
+document.getElementById('snapping-range').addEventListener('input', function(event) {
+  const snappingRange = event.target.value;
+
+  chrome.runtime.sendMessage({ type: 'updateSnappingRange', snappingRange }, function(response) {
+    if (response.status === 'success') {
+      console.log('Snapping range updated');
+    } else {
+      console.error('Failed to update snapping range');
+    }
+  });
+});
+
+chrome.storage.local.get(['snappingEnabled', 'snappingRange'], (result) => {
+  document.getElementById('snapping-checkbox').checked = result.snappingEnabled !== undefined ? result.snappingEnabled : false;
+  document.getElementById('snapping-range').value = result.snappingRange !== undefined ? result.snappingRange : 10;
+});
+
 document.getElementById('grid-width').value = 1680;

--- a/styles.css
+++ b/styles.css
@@ -57,3 +57,20 @@
   transform-origin: 0 0;
   z-index: 10000;
 }
+
+/* P8d36 */
+#snap-dot {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  background: red;
+  border-radius: 50%;
+  z-index: 10001;
+}
+
+/* P019d */
+.snapped-edge {
+  position: absolute;
+  background: rgba(255, 0, 0, 0.5);
+  z-index: 10001;
+}


### PR DESCRIPTION
Add snapping functionality to the ruler tool extension.

* **popup.html**
  - Add a checkbox to enable/disable snapping to webpage elements' edges.
  - Add a label for the new checkbox.
  - Add a range input to set the snapping range.

* **popup.js**
  - Add event listener for the new checkbox to send a message to `content.js`.
  - Add event listener for the range input to send a message to `content.js`.
  - Update the initialization to set the checkbox and range input state based on stored values.

* **content.js**
  - Add variables to store the snapping state, snapping range, and snap dot.
  - Add logic to snap the line to the nearest webpage element's edge.
  - Add a red dot to indicate the current snap position.
  - Update the message listener to handle the new snapping state and range messages.
  - Display the snapped edges when snapping is enabled.

* **styles.css**
  - Add styles for the red dot indicating the snap position.
  - Add styles for displaying the snapped edges.

